### PR TITLE
feat: Add computed_arn output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1]
+### Added
+- feat: Add `computed_arn` output.
+
 ## [0.4.0]
 ### Changed
 - BREAKING: Enable point-in-time recovery by default. Set `point_in_time_recovery_enabled = false` if desired.
@@ -66,9 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Server Side Encryption (SSE)
 
 <!-- markdown-link-check-disable -->
-[Unreleased]: https://github.com/mineiros-io/terraform-module-template/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/mineiros-io/terraform-module-template/compare/v0.3.0...v0.4.0
+[Unreleased]: https://github.com/mineiros-io/terraform-module-template/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/mineiros-io/terraform-module-template/compare/v0.4.0...v0.4.1
 <!-- markdown-link-check-disabled -->
+[0.4.0]: https://github.com/mineiros-io/terraform-module-template/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/mineiros-io/terraform-module-template/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/mineiros-io/terraform-module-template/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/mineiros-io/terraform-module-template/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -324,6 +324,12 @@ The following attributes are exported by the module:
 
   The full `aws_dynamodb_table` object with all its attributes.
 
+- **`computed_arn`**
+
+  Computed table arn in the format: `arn:aws:dynamodb:<region>:<account_id>:table/<name>`.
+  This value can be used to create predictable policies in cases where terraform depends on the ARN of the table that will be created in the plan phase but can only access the ARN of the table after applying it.
+
+
 ## External Documentation
 
 - AWS Documentation IAM:

--- a/outputs_computed.tf
+++ b/outputs_computed.tf
@@ -1,0 +1,13 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  region     = data.aws_region.current.name
+  account_id = data.aws_caller_identity.current.account_id
+  table_arn  = "arn:aws:dynamodb:${local.region}:${local.account_id}:table/${var.name}"
+}
+
+output "computed_arn" {
+  description = "Computed table arn in the format: arn:aws:dynamodb:<region>:<account_id>:table/<name>"
+  value       = var.module_enabled ? local.table_arn : null
+}


### PR DESCRIPTION
This predicts the ARN of the to be created dynamodb table.
This can be used to circumvent issues with computed values when creating
dependent resources such as policies.
